### PR TITLE
Add a predicate method to embeddable

### DIFF
--- a/lib/embeddable.rb
+++ b/lib/embeddable.rb
@@ -53,6 +53,10 @@ module Embeddable
         end.flatten.compact.first
       end
 
+      define_method "#{name}?" do
+        send("#{name}_id") ? true : false
+      end
+
       SERVICES.each do |service, pattern|
 
         define_method "#{name}_on_#{service}?" do

--- a/spec/lib/embeddable_spec.rb
+++ b/spec/lib/embeddable_spec.rb
@@ -19,6 +19,22 @@ describe Embeddable do
     end
   end
 
+  describe 'predicate' do
+    context ':video_url is a supported url' do
+      it 'should be true' do
+        subject.video_url = 'http://youtube.com/watch?v=1&feature=foo'
+        expect(subject.video?).to be_truthy
+      end
+    end
+
+    context ':video_url is an unsupported url' do
+      it 'should be false' do
+        subject.video_url = 'http://foo.bar'
+        expect(subject.video?).to be_falsey
+      end
+    end
+  end
+
   describe 'Liveleak' do
     context 'with http://liveleak.com/...' do
       before { 


### PR DESCRIPTION
The rspec gem has been updated here https://github.com/hyperoslo/embeddable/pull/10 it fixes the issue with deprecated `its`.

We should probably wait for https://github.com/hyperoslo/embeddable/pull/10 to be merged before we merge this. :smiley: 
